### PR TITLE
Optimize memory usage

### DIFF
--- a/ModTools/Commands/CheckTargetCommand.cs
+++ b/ModTools/Commands/CheckTargetCommand.cs
@@ -19,8 +19,7 @@ internal sealed class CheckTargetCommand
 
         foreach (FileInfo path in filePaths)
         {
-            byte[] data = File.ReadAllBytes(path.FullName);
-            using AssetBundleHelper helper = AssetBundleHelper.FromData(data, path.FullName);
+            using AssetBundleHelper helper = AssetBundleHelper.FromPath(path.FullName);
 
             foreach (AssetsFileInstance fileInstance in helper.FileInstances)
             {

--- a/ModTools/Commands/Manifest/MergeCommand.cs
+++ b/ModTools/Commands/Manifest/MergeCommand.cs
@@ -175,9 +175,7 @@ internal sealed class MergeCommand
     {
         var newArray = newAssetVector["Array"];
 
-        using AssetBundleHelper helper = AssetBundleHelper.FromPath(
-            bundlePath.FullName
-        );
+        using AssetBundleHelper helper = AssetBundleHelper.FromPath(bundlePath.FullName);
 
         var containers = helper
             .GetAllBaseFields(0)

--- a/ModTools/Commands/Manifest/MergeCommand.cs
+++ b/ModTools/Commands/Manifest/MergeCommand.cs
@@ -88,7 +88,7 @@ internal sealed class MergeCommand
         targetHelper.UpdateBaseField("manifest", targetBaseField);
 
         string outputPath = Path.Join(
-            Path.GetDirectoryName(outputBundleDir),
+            Path.GetDirectoryName(outputManifestDir),
             Path.GetFileName(sourcePath)
         );
 

--- a/ModTools/Commands/Manifest/MergeCommand.cs
+++ b/ModTools/Commands/Manifest/MergeCommand.cs
@@ -174,10 +174,8 @@ internal sealed class MergeCommand
     private static void PopulateAssetArray(AssetTypeValueField newAssetVector, FileInfo bundlePath)
     {
         var newArray = newAssetVector["Array"];
-        byte[] bundleData = File.ReadAllBytes(bundlePath.FullName);
 
-        using AssetBundleHelper helper = AssetBundleHelper.FromData(
-            bundleData,
+        using AssetBundleHelper helper = AssetBundleHelper.FromPath(
             bundlePath.FullName
         );
 

--- a/ModTools/Commands/Manifest/MergeCommand.cs
+++ b/ModTools/Commands/Manifest/MergeCommand.cs
@@ -186,9 +186,8 @@ internal sealed class MergeCommand
     {
         var newArray = newAssetVector["Array"];
 
-        using AssetBundleHelper helper = AssetBundleHelper.FromPath(bundlePath.FullName);
-
-        var newElements = GetContainerNames(helper.GetAllBaseFields(0))
+        var newElements = helper
+            .GetContainerNames()
             .Select(x =>
             {
                 var newValue = ValueBuilder.DefaultValueFieldFromArrayTemplate(newArray);
@@ -197,40 +196,6 @@ internal sealed class MergeCommand
             });
 
         newArray.Children.AddRange(newElements);
-        return;
-
-        static IEnumerable<string> GetContainerNames(IEnumerable<AssetTypeValueField> fields)
-        {
-            foreach (AssetTypeValueField assetField in fields)
-            {
-                if (assetField["m_Container"] is not { IsDummy: false } container)
-                    continue;
-
-                string containerName = container[0][0][0].AsString;
-                containerName = containerName.Replace(
-                    "assets/_gluonresources/",
-                    "",
-                    StringComparison.Ordinal
-                );
-                containerName = containerName.Replace("resources/", "", StringComparison.Ordinal);
-                yield return containerName;
-            }
-        }
-    }
-
-    private static string? GetContainer(AssetTypeValueField assetField)
-    {
-        if (assetField["m_Container"] is not { IsDummy: false } container)
-            return null;
-
-        string containerName = container[0][0][0].AsString;
-        containerName = containerName.Replace(
-            "assets/_gluonresources/",
-            "",
-            StringComparison.Ordinal
-        );
-        containerName = containerName.Replace("resources/", "", StringComparison.Ordinal);
-        return containerName;
     }
 }
 

--- a/ModTools/Commands/Manifest/MergeCommand.cs
+++ b/ModTools/Commands/Manifest/MergeCommand.cs
@@ -16,6 +16,7 @@ internal sealed class MergeCommand
     /// <param name="outputBundleDir">--output-bundles|-b, The path to a directory to output the new bundles to.</param>
     /// <param name="assetDirectories">--assets-path|-a, Comma-separated list of directories to source the added asset bundles from.</param>
     /// <param name="conversion">--convert|-c, Whether to convert assets to iOS during the merge process.</param>
+    /// <param name="readFromDisk">Whether to decrease memory usage, at the expense of performance, by reading bundles directly from disk without loading them into memory first.</param>
     [Command("merge")]
     public void Command(
         string targetPath,
@@ -23,9 +24,12 @@ internal sealed class MergeCommand
         string outputManifestDir,
         string outputBundleDir,
         string[] assetDirectories,
-        bool conversion
+        bool conversion,
+        bool readFromDisk
     )
     {
+        SharedOptionContext.ReadFromDisk = readFromDisk;
+
         using AssetBundleHelper targetHelper = AssetBundleHelper.FromPathEncrypted(targetPath);
         using AssetBundleHelper sourceHelper = AssetBundleHelper.FromPathEncrypted(sourcePath);
 

--- a/ModTools/Shared/AssetBundleHelper.cs
+++ b/ModTools/Shared/AssetBundleHelper.cs
@@ -96,13 +96,12 @@ internal sealed class AssetBundleHelper : IDisposable
         return new AssetBundleHelper(manager, bundleFileInstance);
     }
 
-    public IList<AssetTypeValueField> GetAllBaseFields(int fileIndex = 0)
+    public IEnumerable<AssetTypeValueField> GetAllBaseFields(int fileIndex = 0)
     {
         return this.FileInstances[fileIndex]
             .file.AssetInfos.Select(x =>
                 this.manager.GetBaseField(this.FileInstances[fileIndex], x)
-            )
-            .ToList();
+            );
     }
 
     public AssetTypeValueField GetBaseField(string assetName, int fileIndex = 0)

--- a/ModTools/Shared/AssetBundleHelper.cs
+++ b/ModTools/Shared/AssetBundleHelper.cs
@@ -112,12 +112,21 @@ internal sealed class AssetBundleHelper : IDisposable
         return new AssetBundleHelper(manager, bundleFileInstance);
     }
 
-    public IEnumerable<AssetTypeValueField> GetAllBaseFields(int fileIndex = 0)
+    public IEnumerable<string> GetContainerNames(int fileIndex = 0)
     {
-        return this.FileInstances[fileIndex]
-            .file.AssetInfos.Select(x =>
-                this.manager.GetBaseField(this.FileInstances[fileIndex], x)
-            );
+        AssetsFileInstance assetsFileInstance = this.fileInstances[fileIndex];
+
+        var assetBundleInfo = this.manager.GetBaseField(
+            assetsFileInstance,
+            assetsFileInstance.file.GetAssetInfo(pathId: 1)
+        );
+
+        var container = assetBundleInfo["m_Container.Array"];
+        foreach (var containerChild in container.Children)
+        {
+            string name = containerChild[0].AsString;
+            yield return name;
+        }
     }
 
     public AssetTypeValueField GetBaseField(string assetName, int fileIndex = 0)

--- a/ModTools/Shared/AssetBundleHelper.cs
+++ b/ModTools/Shared/AssetBundleHelper.cs
@@ -1,4 +1,5 @@
-﻿using AssetsTools.NET;
+﻿using System.Buffers;
+using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 
 namespace ModTools.Shared;
@@ -24,6 +25,12 @@ internal sealed class AssetBundleHelper : IDisposable
                 .Select((x, idx) => (x, idx))
         )
         {
+            if (name.EndsWith(".resS", StringComparison.InvariantCultureIgnoreCase))
+            {
+                ConsoleApp.Log($"Skipping streamed assets file instance {name} at index {idx}");
+                continue;
+            }
+            
             AssetsFileInstance instance;
             try
             {
@@ -35,7 +42,7 @@ internal sealed class AssetBundleHelper : IDisposable
             }
             catch
             {
-                Console.Error.WriteLine(
+                ConsoleApp.LogError(
                     $"[ERROR] Failed to load file instance {name} at index {idx}"
                 );
                 throw;
@@ -43,8 +50,7 @@ internal sealed class AssetBundleHelper : IDisposable
 
             if (instance == null)
             {
-                // Probably a .resS file
-                ConsoleApp.Log($"Skipping file instance {name} at index {idx}");
+                ConsoleApp.LogError($"[WARNING] Skipping null file instance {name} at index {idx}");
                 continue;
             }
 

--- a/ModTools/Shared/AssetBundleHelper.cs
+++ b/ModTools/Shared/AssetBundleHelper.cs
@@ -30,7 +30,7 @@ internal sealed class AssetBundleHelper : IDisposable
                 ConsoleApp.Log($"Skipping streamed assets file instance {name} at index {idx}");
                 continue;
             }
-            
+
             AssetsFileInstance instance;
             try
             {
@@ -42,9 +42,7 @@ internal sealed class AssetBundleHelper : IDisposable
             }
             catch
             {
-                ConsoleApp.LogError(
-                    $"[ERROR] Failed to load file instance {name} at index {idx}"
-                );
+                ConsoleApp.LogError($"[ERROR] Failed to load file instance {name} at index {idx}");
                 throw;
             }
 
@@ -67,22 +65,24 @@ internal sealed class AssetBundleHelper : IDisposable
     {
         FileInfo fileInfo = new(path);
         int fileSize = checked((int)fileInfo.Length);
-        
+
         byte[] encryptedArray = ArrayPool<byte>.Shared.Rent(fileSize);
-        Span<byte> encryptedSpan = new(encryptedArray, 0, fileSize); 
+        Span<byte> encryptedSpan = new(encryptedArray, 0, fileSize);
 
         using FileStream encryptedFs = File.OpenRead(path);
-        int bytesRead  = encryptedFs.Read(encryptedSpan);
-        
+        int bytesRead = encryptedFs.Read(encryptedSpan);
+
         if (bytesRead < fileSize)
         {
-            throw new IOException($"Failed to read all of the file: read {bytesRead} bytes, but expected {fileSize} bytes");
+            throw new IOException(
+                $"Failed to read all of the file: read {bytesRead} bytes, but expected {fileSize} bytes"
+            );
         }
-        
+
         byte[] data = RijndaelHelper.Decrypt(encryptedSpan);
 
         ArrayPool<byte>.Shared.Return(encryptedArray);
-        
+
         return FromData(data, path);
     }
 

--- a/ModTools/Shared/BundleConversionHelper.cs
+++ b/ModTools/Shared/BundleConversionHelper.cs
@@ -6,8 +6,7 @@ internal static class BundleConversionHelper
 {
     public static void ConvertToIos(FileInfo input, FileInfo output)
     {
-        using AssetBundleHelper bundleHelper = AssetBundleHelper.FromData(
-            File.ReadAllBytes(input.FullName),
+        using AssetBundleHelper bundleHelper = AssetBundleHelper.FromPath(
             input.FullName
         );
 

--- a/ModTools/Shared/BundleConversionHelper.cs
+++ b/ModTools/Shared/BundleConversionHelper.cs
@@ -6,9 +6,7 @@ internal static class BundleConversionHelper
 {
     public static void ConvertToIos(FileInfo input, FileInfo output)
     {
-        using AssetBundleHelper bundleHelper = AssetBundleHelper.FromPath(
-            input.FullName
-        );
+        using AssetBundleHelper bundleHelper = AssetBundleHelper.FromPath(input.FullName);
 
         ConvertToIos(bundleHelper, output);
     }

--- a/ModTools/Shared/RijndaelHelper.cs
+++ b/ModTools/Shared/RijndaelHelper.cs
@@ -29,11 +29,11 @@ internal static class RijndaelHelper
 
         return final;
     }
-    
+
     public static byte[] Decrypt(ReadOnlySpan<byte> encrypted)
     {
         PaddedBufferedBlockCipher cipher = CreateCipher(forEncryption: false);
-        
+
         // The file contains a SHA256 hash as the final 32 bytes - this should be removed before decrypting.
         int dataSize = encrypted.Length - 32;
         int outputSize = cipher.GetOutputSize(dataSize);

--- a/ModTools/Shared/SharedOptionContext.cs
+++ b/ModTools/Shared/SharedOptionContext.cs
@@ -1,0 +1,6 @@
+namespace ModTools.Shared;
+
+internal static class SharedOptionContext
+{
+    public static bool ReadFromDisk { get; set; }
+}

--- a/SerializedDictionaryPlugin.Shared/SerializableDictionaryHelper.cs
+++ b/SerializedDictionaryPlugin.Shared/SerializableDictionaryHelper.cs
@@ -76,17 +76,17 @@ public static partial class SerializableDictionaryHelper
         AssetTypeValueField dict = baseField["dict"];
         int count = dict["count"].AsInt;
 
-        IEnumerable<string> keys = dict["entriesKey.Array"].Children
-            .Select(x => x.AsString)
+        IEnumerable<string> keys = dict["entriesKey.Array"]
+            .Children.Select(x => x.AsString)
             .Take(count);
-        IEnumerable<JsonElement> values = dict["entriesValue.Array"].Children.Select(
-            x =>
+        IEnumerable<JsonElement> values = dict["entriesValue.Array"]
+            .Children.Select(x =>
                 JsonSerializer.SerializeToElement(
                     x.Children.ToDictionary(c => c.FieldName, GetPrimitiveFieldValue),
                     typeof(Dictionary<string, object>),
                     SharedSerializerContext.Default
                 )
-        );
+            );
 
         Dictionary<string, JsonElement> newDict = keys.Zip(values)
             .ToDictionary(x => x.First, x => x.Second);

--- a/SerializedDictionaryPlugin.Shared/SerializableDictionaryPlugin.Shared.csproj
+++ b/SerializedDictionaryPlugin.Shared/SerializableDictionaryPlugin.Shared.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AssetsTools.NET" Version="3.0.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Some fixes over various code paths that are used in the merging manifest functionality to attempt to lower the memory usage of this command.

Also adds a new option to `merge`, `--read-from-disk` which will skip loading bundle files into a memory buffer and operate on them from disk.

On `master`, memory usage sits at around 500MB for the command and spikes at almost 900MB:

![image](https://github.com/user-attachments/assets/257e5c3c-4230-417d-99ee-bb701d1f516d)

On this branch with the new option it spikes at just over 500MB:

![image](https://github.com/user-attachments/assets/643bb0c8-03a5-439d-885c-b52ac0e00e14)


